### PR TITLE
if no triple generated, used srcid as key for pred_confidences dict

### DIFF
--- a/plastering/inferencers/inferencer.py
+++ b/plastering/inferencers/inferencer.py
@@ -318,6 +318,8 @@ class Inferencer(object):
     def add_pred(self, pred_g, pred_confidences,
                  srcid, pred_point, pred_prob):
         triple = pred_g.add_pred_point_result(srcid, pred_point)
+        if triple is None:
+            triple = srcid
         pred_confidences[triple] = pred_prob
 
 


### PR DESCRIPTION
I am using Zodiac for predicting point tagsets, and not a Brick graph. In `Inferencer.add_pred`, the storing of prediction confidences in a dictionary is facilitated by Turtle triples acting as keys. However, due to the nature of my data, these triples were being returned as `None`. As a result, the dictionary was incorrectly storing prediction confidences, just repeatedly overwriting a single dict entry with the key `None`.

To fix this, I added a check for `None` and in that case, I set the key to the point's srcid.